### PR TITLE
Fix findById method in ProductService

### DIFF
--- a/src/main/java/com/revature/services/ProductService.java
+++ b/src/main/java/com/revature/services/ProductService.java
@@ -45,9 +45,8 @@ public class ProductService {
     public Optional<Product> findById(int id) {
         Optional<Product> optionalProduct = productRepository.findById(id);
 
-        if (optionalProduct.isPresent()) {
-            logger.info(String.format("Product with ID: %d successfully found", optionalProduct.get().getId()));
-        }
+        optionalProduct.ifPresent(
+                product -> logger.info(String.format("Product with ID: %d successfully found", product.getId())));
 
         return optionalProduct;
     }

--- a/src/main/java/com/revature/services/ProductService.java
+++ b/src/main/java/com/revature/services/ProductService.java
@@ -45,11 +45,9 @@ public class ProductService {
     public Optional<Product> findById(int id) {
         Optional<Product> optionalProduct = productRepository.findById(id);
 
-        if (!optionalProduct.isPresent()) {
-        
-            noId(id);
+        if (optionalProduct.isPresent()) {
+            logger.info(String.format("Product with ID: %d successfully found", optionalProduct.get().getId()));
         }
-        logger.info(String.format("Product with ID: %d successfully found", optionalProduct.get().getId()));
 
         return optionalProduct;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-    port: 5000
+    port: 8080
 spring:
     jpa:
         hibernate:

--- a/src/test/java/com/revature/services/ProductServiceTest.java
+++ b/src/test/java/com/revature/services/ProductServiceTest.java
@@ -1,6 +1,7 @@
 package com.revature.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.BDDMockito.given;
@@ -81,17 +82,15 @@ class ProductServiceTest {
 		verify(this.mockProductRepo, times(1)).findById(id);
 	}
 	
-//	@Test
-//	void testFindById_Failure_ProductNotFound() {
-//		int id = 404;
-//		given(this.mockProductRepo.findById(id)).willReturn(Optional.empty());
-//		try {
-//			this.pServ.findById(id);
-//			fail("Expected ProductNotFoundException to be throw");
-//		} catch (Exception e) {
-//			assertEquals(ProductNotFoundException.class, e.getClass());
-//		}
-//	}
+	@Test
+	void testFindById_ProductNotFound() {
+		int id = 404;
+		given(this.mockProductRepo.findById(id)).willReturn(Optional.empty());
+		
+		Optional<Product> optionalProduct = this.pServ.findById(id);
+		assertFalse(optionalProduct.isPresent());
+		verify(this.mockProductRepo, times(1)).findById(id);
+	}
 
 	@Test
 	void testSave() {


### PR DESCRIPTION
This should fix many actions related to managing the shop inventory, notably inserting items and deleting those without any reviews.

When a product doesn't exist (yet), `ProductController` methods expect an empty `Optional` object instead of `ProductNotFoundException` being thrown.